### PR TITLE
Support for serverless-finch

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ class ServerlessPlugin {
 
     this.hooks = {
       'before:deploy:deploy': this.mfa.bind(this),
+      'before:client:deploy:deploy': this.mfa.bind(this)
     };
   }
 


### PR DESCRIPTION
[serverless-finch](https://github.com/fernando-mc/serverless-finch/blob/master/index.js#L43) uses different hooks than the standard deploy hooks.